### PR TITLE
Configure Authservice from a secret instead of a statefulset

### DIFF
--- a/stacks/openshift/application/oidc-authservice-for-appid/README.md
+++ b/stacks/openshift/application/oidc-authservice-for-appid/README.md
@@ -16,7 +16,7 @@ OIDC auth service:
 
 ## How to use
 
-1. Create the namespace `istio-system` if you don't have it:
+1. Create the namespace `istio-system` if not exist:
 ```SHELL
 kubectl create namespace istio-system
 ```
@@ -31,13 +31,14 @@ kubectl create secret generic appid-application-configuration -n istio-system \
 * `<oAuthServerUrl>` - fill in the value of `oAuthServerUrl`
 * `<clientId>` - fill in the value of `clientId`
 * `<secret>` - fill in the value of `secret`
-* `<routeFQDN>` - fill in the public endpoint of istio ingressgateway.
+* `<routeFQDN>` - fill in the FQDN of OpenShift Route of istio ingress gateway
 
-Notice that the environment variable `REDIRECT_URL` should be updated with the
-actual FQDN of public endpoint of istio ingressgateway, either via ingress or
-route. And please keep the path to `/login/oidc`.
+Notice that it recommend using HTTPS for the value of `oidcRedirectUrl`, which
+requires additional setup:
+1. enable [TLS passthrough](https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html#passthrough-termination) mode for the route.
+2. expose kubeflow dashboard over HTTPS by following steps of [this section](https://www.kubeflow.org/docs/ibm/deploy/authentication/#exposing-the-kubeflow-dashboard-with-dns-and-tls-termination).
 
 After deploying Kubeflow successfully, you will need to add the value of
-`oidcRedirectUrl` to the IBM Cloud AppID instance under the _Authentication 
-Settings_ of the _Manage Authentication_ menu. Or AppID won't redirect authenticated requests
-back to Kubeflow.
+`https://<routeFQDN>/login/oidc` to the IBM Cloud AppID instance under the
+_Authentication Settings_ of the _Manage Authentication_ menu. Or AppID won't
+redirect authenticated requests back to Kubeflow.

--- a/stacks/openshift/application/oidc-authservice-for-appid/README.md
+++ b/stacks/openshift/application/oidc-authservice-for-appid/README.md
@@ -16,7 +16,11 @@ OIDC auth service:
 
 ## How to use
 
-Create a secret prior to kubeflow deployment by filling parameters accordingly:
+1. Create the namespace `istio-system` if you don't have it:
+```SHELL
+kubectl create namespace istio-system
+```
+2. Create a secret prior to kubeflow deployment by filling parameters accordingly:
 ```SHELL
 kubectl create secret generic appid-application-configuration -n istio-system \
   --from-literal=clientId=<clientId> \
@@ -24,7 +28,6 @@ kubectl create secret generic appid-application-configuration -n istio-system \
   --from-literal=oAuthServerUrl=<oAuthServerUrl> \
   --from-literal=oidcRedirectUrl=https://<routeFQDN>/login/oidc
 ```
-
 * `<oAuthServerUrl>` - fill in the value of `oAuthServerUrl`
 * `<clientId>` - fill in the value of `clientId`
 * `<secret>` - fill in the value of `secret`

--- a/stacks/openshift/application/oidc-authservice-for-appid/README.md
+++ b/stacks/openshift/application/oidc-authservice-for-appid/README.md
@@ -5,6 +5,7 @@
 * Provisioning an [AppID](https://cloud.ibm.com/catalog/services/app-id) 
 instance from IBM Cloud. It can start with the _Lite_ plan, but will need the
 _Graduated tier_ once you need more than 1000 authentication events per month.
+* FQDN of OpenShift Route of istio ingress gateway.
 * Create an application with type _reguarwebapp_ under the provioned AppID
 instance. Make sure the caope contains `email` and retrieve the following
 configuration parameters from your AppID. They will be used to configure the
@@ -15,18 +16,25 @@ OIDC auth service:
 
 ## How to use
 
-This configuration should be included as part of kubeflow deployment. After a successful Kubeflow deployment, you will find no pod running in the statefulset
-`authservice` in namespace `istio-system`. It will need to fill in valid 
-configuration from the environment variables via either web console or CLI with parameters from AppID instance:
-* `OIDC_PROVIDER` - fill in the value of `oAuthServerUrl`
-* `CLIENT_ID` - fill in the value of `clientId`
-* `CLIENT_SECRET` - fill in the value of `secret`
-* `REDIRECT_URL` - fill in `https://<hostname-of-the-route-istio-ingressgateway>/login/oidc`
+Create a secret prior to kubeflow deployment by filling parameters accordingly:
+```SHELL
+kubectl create secret generic appid-application-configuration -n istio-system \
+  --from-literal=clientId=<clientId> \
+  --from-literal=secret=<secret> \
+  --from-literal=oAuthServerUrl=<oAuthServerUrl> \
+  --from-literal=oidcRedirectUrl=https://<routeFQDN>/login/oidc
+```
+
+* `<oAuthServerUrl>` - fill in the value of `oAuthServerUrl`
+* `<clientId>` - fill in the value of `clientId`
+* `<secret>` - fill in the value of `secret`
+* `<routeFQDN>` - fill in the public endpoint of istio ingressgateway.
 
 Notice that the environment variable `REDIRECT_URL` should be updated with the
 actual FQDN of public endpoint of istio ingressgateway, either via ingress or
 route. And please keep the path to `/login/oidc`.
 
-After updating the statusfulset `authservice`, you will need to add the value of
-`REDIRECT_URL` to the AppID instance under the _Authentication Settings_ of the _Manage Authentication_ menu. Or AppID won't redirect authenticated requests
+After deploying Kubeflow successfully, you will need to add the value of
+`oidcRedirectUrl` to the IBM Cloud AppID instance under the _Authentication 
+Settings_ of the _Manage Authentication_ menu. Or AppID won't redirect authenticated requests
 back to Kubeflow.

--- a/stacks/openshift/application/oidc-authservice-for-appid/container-env-vars.yaml
+++ b/stacks/openshift/application/oidc-authservice-for-appid/container-env-vars.yaml
@@ -1,0 +1,32 @@
+- op: replace
+  path: /spec/template/spec/containers/0/env/3
+  value:
+    name: OIDC_PROVIDER
+    valueFrom:
+      secretKeyRef:
+        key: oAuthServerUrl
+        name: appid-application-configuration
+- op: replace
+  path: /spec/template/spec/containers/0/env/6
+  value:
+    name: REDIRECT_URL
+    valueFrom:
+      secretKeyRef:
+        key: oidcRedirectUrl
+        name: appid-application-configuration
+- op: replace
+  path: /spec/template/spec/containers/0/env/9
+  value:
+    name: CLIENT_ID
+    valueFrom:
+      secretKeyRef:
+        key: clientId
+        name: appid-application-configuration
+- op: replace
+  path: /spec/template/spec/containers/0/env/10
+  value:
+    name: CLIENT_SECRET
+    valueFrom:
+      secretKeyRef:
+        key: secret
+        name: appid-application-configuration

--- a/stacks/openshift/application/oidc-authservice-for-appid/kustomization.yaml
+++ b/stacks/openshift/application/oidc-authservice-for-appid/kustomization.yaml
@@ -11,6 +11,11 @@ commonLabels:
   app.kubernetes.io/name: oidc-authservice
 patches:
 - path: sts-patch.yaml
+- path: container-env-vars.yaml
+  target:
+    version: v1
+    kind: StatefulSet
+    name: authservice
 configMapGenerator:
 - name: oidc-authservice-parameters
   behavior: merge

--- a/stacks/openshift/application/oidc-authservice-for-appid/params.env
+++ b/stacks/openshift/application/oidc-authservice-for-appid/params.env
@@ -1,8 +1,4 @@
-client_id=xxxxxx
-oidc_provider=https://us-east.appid.cloud.ibm.com/oauth/v4/xxxx
-oidc_redirect_uri=https://<kubeflow-gateway-host>/login/oidc
 oidc_auth_url=
-application_secret=yyyyyy
 skip_auth_uri=
 namespace=istio-system
 userid-header=kubeflow-userid


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Supports https://github.com/kubeflow/website/issues/2182

**Description of your changes:**


**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
