### PR TITLE
Fix kfdef typo

### DIFF
--- a/kfdef/kfctl_ibm_customstack.yaml
+++ b/kfdef/kfctl_ibm_customstack.yaml
@@ -9,7 +9,7 @@ spec:
   - kustomizeConfig:
       repoRef:
         name: manifests
-        path: stacks/ibm/application/istio-stack-1-3-1
+        path: stacks/ibm/application/istio-1-3-1-stack
     name: istio-stack
   # istio related components
   - kustomizeConfig:


### PR DESCRIPTION
The isto-1-3-1 path was incorrect in one of the manifests.
