### PR TITLE
use the overlay for knative

### DIFF
--- a/dist/stacks/ibm/application/knative/kustomization.yaml
+++ b/dist/stacks/ibm/application/knative/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../../../../common/knative/knative-serving/base
+- ../../../../../common/knative/knative-serving/overlays/gateways
 - ../../../../../common/istio-1-9/cluster-local-gateway/base
 - ../../../../../common/knative/knative-eventing/base


### PR DESCRIPTION
because of this issue:
https://github.com/kubeflow/manifests/issues/1966
an overlay is created. need to use it instead of the
knative/base

Signed-off-by: Yihong Wang <yh.wang@ibm.com>