### PR TITLE
Remove `emptyDir` `build-volume` from `mlx-ui`

### DIFF
--- a/contrib/mlx/base/mlx-deployments/mlx-ui.yaml
+++ b/contrib/mlx/base/mlx-deployments/mlx-ui.yaml
@@ -68,9 +68,6 @@ spec:
           name: dashboard-admin
           readOnly: true
           # When deploying MLX on OpenShift, readOnly SCC may be required for mlx-ui.
-        - mountPath: /workspace/build
-          name: build-volume
-          # When deploying MLX on OpenShift, emptydir volume is required for mlx-ui.
       volumes:
       - name: dashboard-admin
         secret:
@@ -78,8 +75,6 @@ spec:
           - key: admin.json
             path: admin.json
           secretName: mlx-dashboard-admin
-      - name: build-volume
-        emptyDir: {}
       serviceAccountName: mlx-ui
 ---
 apiVersion: v1


### PR DESCRIPTION
**Description of your changes:**

After changes to the [mlx-ui Docker image](https://github.com/machine-learning-exchange/mlx/pull/339), we no longer require the externally mounted build volume

/cc @Tomcli  @yhwang 

FYI @jbusche

**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
