### PR TITLE
Update MLX deployments on OCP on Fyre

### DIFF
--- a/apps/kubebench/upstream/base/cluster-role-binding.yaml
+++ b/apps/kubebench/upstream/base/cluster-role-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kubebench-operator

--- a/apps/kubebench/upstream/base/cluster-role.yaml
+++ b/apps/kubebench/upstream/base/cluster-role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: kubebench-operator

--- a/contrib/mlx/base/mlx-deployments/mlx-api.yaml
+++ b/contrib/mlx/base/mlx-deployments/mlx-api.yaml
@@ -59,7 +59,7 @@ spec:
           periodSeconds: 60
           failureThreshold: 3
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: mlx-api-access

--- a/contrib/spartakus/base/cluster-role-binding.yaml
+++ b/contrib/spartakus/base/cluster-role-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:

--- a/contrib/spartakus/base/cluster-role.yaml
+++ b/contrib/spartakus/base/cluster-role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:

--- a/contrib/tektoncd/tektoncd-install/base/cluster-role-binding.yaml
+++ b/contrib/tektoncd/tektoncd-install/base/cluster-role-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: tekton-pipelines-controller-cluster-access
@@ -17,7 +17,7 @@ roleRef:
 # then the ClusterRole would be namespaced. The access described by
 # the tekton-pipelines-controller-tenant-access ClusterRole would
 # be scoped to individual tenant namespaces.
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: tekton-pipelines-controller-tenant-access
@@ -32,7 +32,7 @@ roleRef:
   name: tekton-pipelines-controller-tenant-access
   apiGroup: rbac.authorization.k8s.io
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: tekton-pipelines-webhook-cluster-access

--- a/contrib/tektoncd/tektoncd-install/base/role-binding.yaml
+++ b/contrib/tektoncd/tektoncd-install/base/role-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: tekton-pipelines-controller
@@ -14,7 +14,7 @@ roleRef:
   name: tekton-pipelines-controller
   apiGroup: rbac.authorization.k8s.io
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: tekton-pipelines-webhook
@@ -30,7 +30,7 @@ roleRef:
   name: tekton-pipelines-webhook
   apiGroup: rbac.authorization.k8s.io
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: tekton-pipelines-controller-leaderelection
@@ -46,7 +46,7 @@ roleRef:
   name: tekton-pipelines-leader-election
   apiGroup: rbac.authorization.k8s.io
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: tekton-pipelines-webhook-leaderelection

--- a/docs/dex-auth/examples/authorization/Kubernetes/cluster_read_all_cluster_role_binding.yaml
+++ b/docs/dex-auth/examples/authorization/Kubernetes/cluster_read_all_cluster_role_binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cluster-read-all-role-binding

--- a/docs/dex-auth/examples/authorization/Kubernetes/cluster_write_all_cluster_role_binding.yaml
+++ b/docs/dex-auth/examples/authorization/Kubernetes/cluster_write_all_cluster_role_binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cluster-write-all-role-binding

--- a/docs/dex-auth/examples/authorization/Kubernetes/secrets_write_all_cluster_role_binding.yaml
+++ b/docs/dex-auth/examples/authorization/Kubernetes/secrets_write_all_cluster_role_binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: secrets-write-all-role-binding

--- a/mlx-single-fyre-openshift/kustomization.yaml
+++ b/mlx-single-fyre-openshift/kustomization.yaml
@@ -3,14 +3,13 @@ kind: Kustomization
 
 resources:
 # Istio
-- ../dist/stacks/ibm/application/istio-1-11
+- ../dist/stacks/ibm/application/istio
 # Kubeflow namespace (required)
 - ../dist/stacks/ibm/application/kubeflow-namespace-no-auth
 # Kubeflow Roles (required)
 - ../dist/stacks/ibm/application/kubeflow-roles
 # Kubeflow istio resource (required)
 - ../dist/stacks/ibm/application/kubeflow-istio-resources
-
 
 # Kubeflow Pipelines with Tekton
 - ../dist/stacks/ibm/application/kfp-tekton-no-auth
@@ -20,3 +19,7 @@ resources:
 - ../contrib/mlx/mlx-standalone
 # Openshift SCC
 - ../dist/stacks/ibm/application/openshift/openshift-scc
+
+# Override kubelet path for OpenShift on AWS and Fyre
+patchesStrategicMerge:
+- overlays/csi-s3-deployment.yaml

--- a/mlx-single-fyre-openshift/overlays/csi-s3-deployment.yaml
+++ b/mlx-single-fyre-openshift/overlays/csi-s3-deployment.yaml
@@ -1,0 +1,173 @@
+# Overlays: apps/kfp-tekton/upstream/third-party/kfp-csi-s3/csi-s3-deployment.yaml
+
+# Source: dlf-chart/charts/csi-s3-chart/templates/csi-s3.yaml
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: kfp-csi-s3
+  labels:
+    app.kubernetes.io/name: "kubeflow"
+  namespace: kubeflow
+spec:
+  selector:
+    matchLabels:
+      app: kfp-csi-s3
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: "kubeflow"
+        app: kfp-csi-s3
+    spec:
+      serviceAccountName: kfp-csi-s3
+      containers:
+        - name: driver-registrar
+          image: "quay.io/k8scsi/csi-node-driver-registrar:v1.2.0"
+          imagePullPolicy: Always
+          args:
+            - --v=5
+            - --csi-address=/csi/csi.sock
+            - --kubelet-registration-path=/var/lib/kubelet/plugins/kfp-csi-s3/csi.sock
+          securityContext:
+            # This is necessary only for systems with SELinux, where
+            # non-privileged sidecar containers cannot access unix domain socket
+            # created by privileged CSI driver container.
+            privileged: true
+          env:
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+            - mountPath: /registration
+              name: registration-dir
+        - name: kfp-csi-s3
+          image: "quay.io/datashim/csi-s3:latest-amd64"
+          imagePullPolicy: Always
+          args:
+            - "--v=5"
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--nodeid=$(KUBE_NODE_NAME)"
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: cheap
+              value: "off"
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+            - mountPath: /var/lib/kubelet/pods
+              mountPropagation: Bidirectional
+              name: mountpoint-dir
+            - mountPath: /dev
+              name: dev-dir
+      volumes:
+        - hostPath:
+            path: /var/lib/kubelet/plugins/kfp-csi-s3
+            type: DirectoryOrCreate
+          name: socket-dir
+        - hostPath:
+            path: /var/lib/kubelet/pods
+            type: DirectoryOrCreate
+          name: mountpoint-dir
+        - hostPath:
+            path: /var/lib/kubelet/plugins_registry
+            type: Directory
+          name: registration-dir
+        - hostPath:
+            path: /dev
+            type: Directory
+          name: dev-dir
+---
+# Source: dlf-chart/charts/csi-s3-chart/templates/attacher.yaml
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: csi-attacher-s3
+  namespace: kubeflow
+  labels:
+    app.kubernetes.io/name: "kubeflow"
+spec:
+  serviceName: "csi-attacher-s3"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-attacher-s3
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: "kubeflow"
+        app: csi-attacher-s3
+    spec:
+      serviceAccountName: csi-attacher
+      containers:
+        - name: csi-attacher
+          image: "quay.io/k8scsi/csi-attacher:v2.2.0"
+          imagePullPolicy: Always
+          args:
+            - --v=5
+            - --csi-address=/csi/csi.sock
+          securityContext:
+            # This is necessary only for systems with SELinux, where
+            # non-privileged sidecar containers cannot access unix domain socket
+            # created by privileged CSI driver container.
+            privileged: true
+          volumeMounts:
+          - mountPath: /csi
+            name: socket-dir
+      volumes:
+        - hostPath:
+            path: /var/lib/kubelet/plugins/kfp-csi-s3
+            type: DirectoryOrCreate
+          name: socket-dir
+---
+# Source: dlf-chart/charts/csi-s3-chart/templates/provisioner.yaml
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: csi-provisioner-s3
+  labels:
+    app.kubernetes.io/name: "kubeflow"
+  namespace: kubeflow
+spec:
+  serviceName: "csi-provisioner-s3"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-provisioner-s3
+  template:
+    metadata:
+      labels:
+        app: csi-provisioner-s3
+    spec:
+      serviceAccountName: csi-provisioner
+      containers:
+        - name: csi-provisioner
+          image: "quay.io/k8scsi/csi-provisioner:v2.0.2"
+          imagePullPolicy: Always
+          args:
+            - -v=5
+            - --csi-address=/csi/csi.sock
+            - --feature-gates=Topology=true
+          securityContext:
+            # This is necessary only for systems with SELinux, where
+            # non-privileged sidecar containers cannot access unix domain socket
+            # created by privileged CSI driver container.
+            privileged: true
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+      volumes:
+        - hostPath:
+            path: /var/lib/kubelet/plugins/kfp-csi-s3
+            type: DirectoryOrCreate
+          name: socket-dir

--- a/mlx-single-ibmcloud-openshift/kustomization.yaml
+++ b/mlx-single-ibmcloud-openshift/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 resources:
 # Istio
-- ../dist/stacks/ibm/application/istio-1-11
+- ../dist/stacks/ibm/application/istio
 # Kubeflow namespace (required)
 - ../dist/stacks/ibm/application/kubeflow-namespace-no-auth
 # Kubeflow Roles (required)

--- a/mlx-single-ibmcloud/kustomization.yaml
+++ b/mlx-single-ibmcloud/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 resources:
 # Istio
-- ../dist/stacks/ibm/application/istio-1-11
+- ../dist/stacks/ibm/application/istio
 # Kubeflow namespace (required)
 - ../dist/stacks/ibm/application/kubeflow-namespace-no-auth
 # Kubeflow Roles (required)

--- a/mlx-single-kind/kustomization.yaml
+++ b/mlx-single-kind/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 resources:
 # Istio
-- ../dist/stacks/ibm/application/istio-1-11
+- ../dist/stacks/ibm/application/istio
 # Kubeflow namespace (required)
 - ../dist/stacks/ibm/application/kubeflow-namespace-no-auth
 # Kubeflow Roles (required)
@@ -19,3 +19,6 @@ resources:
 # MLX
 - ../contrib/mlx/mlx-standalone
 
+# Override kubelet path for OpenShift on AWS and Fyre
+patchesStrategicMerge:
+- overlays/csi-s3-deployment.yaml

--- a/mlx-single-kind/overlays/csi-s3-deployment.yaml
+++ b/mlx-single-kind/overlays/csi-s3-deployment.yaml
@@ -1,0 +1,173 @@
+# Overlays: apps/kfp-tekton/upstream/third-party/kfp-csi-s3/csi-s3-deployment.yaml
+
+# Source: dlf-chart/charts/csi-s3-chart/templates/csi-s3.yaml
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: kfp-csi-s3
+  labels:
+    app.kubernetes.io/name: "kubeflow"
+  namespace: kubeflow
+spec:
+  selector:
+    matchLabels:
+      app: kfp-csi-s3
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: "kubeflow"
+        app: kfp-csi-s3
+    spec:
+      serviceAccountName: kfp-csi-s3
+      containers:
+        - name: driver-registrar
+          image: "quay.io/k8scsi/csi-node-driver-registrar:v1.2.0"
+          imagePullPolicy: Always
+          args:
+            - --v=5
+            - --csi-address=/csi/csi.sock
+            - --kubelet-registration-path=/var/lib/kubelet/plugins/kfp-csi-s3/csi.sock
+          securityContext:
+            # This is necessary only for systems with SELinux, where
+            # non-privileged sidecar containers cannot access unix domain socket
+            # created by privileged CSI driver container.
+            privileged: true
+          env:
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+            - mountPath: /registration
+              name: registration-dir
+        - name: kfp-csi-s3
+          image: "quay.io/datashim/csi-s3:latest-amd64"
+          imagePullPolicy: Always
+          args:
+            - "--v=5"
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--nodeid=$(KUBE_NODE_NAME)"
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: cheap
+              value: "off"
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+            - mountPath: /var/lib/kubelet/pods
+              mountPropagation: Bidirectional
+              name: mountpoint-dir
+            - mountPath: /dev
+              name: dev-dir
+      volumes:
+        - hostPath:
+            path: /var/lib/kubelet/plugins/kfp-csi-s3
+            type: DirectoryOrCreate
+          name: socket-dir
+        - hostPath:
+            path: /var/lib/kubelet/pods
+            type: DirectoryOrCreate
+          name: mountpoint-dir
+        - hostPath:
+            path: /var/lib/kubelet/plugins_registry
+            type: Directory
+          name: registration-dir
+        - hostPath:
+            path: /dev
+            type: Directory
+          name: dev-dir
+---
+# Source: dlf-chart/charts/csi-s3-chart/templates/attacher.yaml
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: csi-attacher-s3
+  namespace: kubeflow
+  labels:
+    app.kubernetes.io/name: "kubeflow"
+spec:
+  serviceName: "csi-attacher-s3"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-attacher-s3
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: "kubeflow"
+        app: csi-attacher-s3
+    spec:
+      serviceAccountName: csi-attacher
+      containers:
+        - name: csi-attacher
+          image: "quay.io/k8scsi/csi-attacher:v2.2.0"
+          imagePullPolicy: Always
+          args:
+            - --v=5
+            - --csi-address=/csi/csi.sock
+          securityContext:
+            # This is necessary only for systems with SELinux, where
+            # non-privileged sidecar containers cannot access unix domain socket
+            # created by privileged CSI driver container.
+            privileged: true
+          volumeMounts:
+          - mountPath: /csi
+            name: socket-dir
+      volumes:
+        - hostPath:
+            path: /var/lib/kubelet/plugins/kfp-csi-s3
+            type: DirectoryOrCreate
+          name: socket-dir
+---
+# Source: dlf-chart/charts/csi-s3-chart/templates/provisioner.yaml
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: csi-provisioner-s3
+  labels:
+    app.kubernetes.io/name: "kubeflow"
+  namespace: kubeflow
+spec:
+  serviceName: "csi-provisioner-s3"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-provisioner-s3
+  template:
+    metadata:
+      labels:
+        app: csi-provisioner-s3
+    spec:
+      serviceAccountName: csi-provisioner
+      containers:
+        - name: csi-provisioner
+          image: "quay.io/k8scsi/csi-provisioner:v2.0.2"
+          imagePullPolicy: Always
+          args:
+            - -v=5
+            - --csi-address=/csi/csi.sock
+            - --feature-gates=Topology=true
+          securityContext:
+            # This is necessary only for systems with SELinux, where
+            # non-privileged sidecar containers cannot access unix domain socket
+            # created by privileged CSI driver container.
+            privileged: true
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+      volumes:
+        - hostPath:
+            path: /var/lib/kubelet/plugins/kfp-csi-s3
+            type: DirectoryOrCreate
+          name: socket-dir


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**

Resolves https://github.com/IBM/manifests/issues/42  (kinda)

**Description of your changes:**

- Change `kubelet` path for `Fyre` and `KIND` deployments
- Update `ClusterRole` and `ClusterRoleBinding` from  `v1beta` to `v1`
- Use `istio` instead of `isti-1-11`

/cc @Tomcli @yhwang 

**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
